### PR TITLE
Remove String from used names

### DIFF
--- a/cmd/protoc-gen-go/internal_gengo/main_test.go
+++ b/cmd/protoc-gen-go/internal_gengo/main_test.go
@@ -1,0 +1,20 @@
+package internal_gengo
+
+import (
+	"testing"
+
+	"github.com/infiniteloopcloud/protoc-gen-go-types/parser"
+)
+
+func TestGenerateFile(t *testing.T) {
+	gen, err := parser.Parse("./test_data/test.proto")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, f := range gen.Files {
+		if f.Generate {
+			GenerateFile(gen, f)
+		}
+	}
+}

--- a/cmd/protoc-gen-go/internal_gengo/test_data/test.proto
+++ b/cmd/protoc-gen-go/internal_gengo/test_data/test.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+option go_package = ".;proto";
+
+package proto;
+
+message Test {
+  TimeTime created_at = 1;
+  map<uint64, string> map_field = 2;
+  string test = 3;
+  String other = 43;
+}
+
+message TimeTime {}
+
+message String {
+  string string = 2;
+}

--- a/compiler/protogen/protogen.go
+++ b/compiler/protogen/protogen.go
@@ -617,7 +617,6 @@ func newMessage(gen *Plugin, f *File, parent *Message, desc protoreflect.Message
 	// adding new per-field methods such as setters.
 	usedNames := map[string]bool{
 		"Reset":               true,
-		"String":              true,
 		"ProtoMessage":        true,
 		"Marshal":             true,
 		"Unmarshal":           true,


### PR DESCRIPTION
Reason:
- We need to have String fields to have backward compatibility in the null package.

Important:
- It's important to keep in mind this.