### PR TITLE
Add zero_override field option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ message TimeTime {}
 
 #### Important
 
-Currently the overwritten FieldOptions (go_type, go_import, go_import_alias, zero_override) must be paired with these numbers:
+Currently the overwritten FieldOptions (go_type, go_import, go_import_alias, go_zero_override) must be paired with these numbers:
 go_type = 1001
 go_import = 1002
 go_import_alias = 1003
-zero_override = 1004
+go_zero_override = 1004
 Because `protoc` can't process the extended options, so we can't find the by name, just by place.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Fork of [Protobuf Golang](https://github.com/protocolbuffers/protobuf-go) specialized for type generation
 
-This package supposed to focus on type generation based on proto file. 
+This package supposed to focus on type generation based on proto file.
 
 ### Features compared to original repository
 
@@ -41,8 +41,9 @@ message TimeTime {}
 
 #### Important
 
-Currently the overwritten FieldOptions (go_type, go_import, go_import_alias) must be paired with these numbers:
+Currently the overwritten FieldOptions (go_type, go_import, go_import_alias, zero_override) must be paired with these numbers:
 go_type = 1001
 go_import = 1002
 go_import_alias = 1003
-Because `protoc` can't process the extended options, so we can't find the by name, just by place. 
+zero_override = 1004
+Because `protoc` can't process the extended options, so we can't find the by name, just by place.

--- a/cmd/protoc-gen-go/internal_gengo/main.go
+++ b/cmd/protoc-gen-go/internal_gengo/main.go
@@ -36,10 +36,10 @@ const (
 )
 
 type overrideParams struct {
-	goType        string
-	goImport      string
-	goImportAlias string
-	zeroOverride  string
+	goType         string
+	goImport       string
+	goImportAlias  string
+	goZeroOverride string
 }
 
 // overrideFields stores all the found messages which are created to override types
@@ -198,9 +198,9 @@ func processExtensions(field *protogen.Field) (overrideParams, bool) {
 		case impl.FieldOptionGoImportAlias:
 			override.goImportAlias = ex.Value().String()
 			ok = true
-		case impl.FieldOptionZeroOverride:
+		case impl.FieldOptionGoZeroOverride:
 			log.Log("processExtensions:: zero override found!")
-			override.zeroOverride = ex.Value().String()
+			override.goZeroOverride = ex.Value().String()
 			ok = true
 		}
 	}
@@ -224,8 +224,8 @@ func processUninterpretedOptions(field *protogen.Field) (overrideParams, bool) {
 				case impl.FieldOptionGoImportAlias:
 					override.goImportAlias = string(o.GetStringValue())
 					ok = true
-				case impl.FieldOptionZeroOverride:
-					override.zeroOverride = string(o.GetStringValue())
+				case impl.FieldOptionGoZeroOverride:
+					override.goZeroOverride = string(o.GetStringValue())
 					ok = true
 				}
 			}
@@ -830,9 +830,9 @@ func fieldProtobufTagValue(field *protogen.Field) string {
 
 func fieldDefaultValue(g *protogen.GeneratedFile, f *fileInfo, m *messageInfo, field *protogen.Field, goType string, overrideParam overrideParams, overwritten bool) string {
 	if overwritten {
-		log.Log("custom zero value: %q", overrideParam.zeroOverride)
-		if overrideParam.zeroOverride != "" {
-			return overrideParam.zeroOverride
+		log.Log("custom zero value: %q", overrideParam.goZeroOverride)
+		if overrideParam.goZeroOverride != "" {
+			return overrideParam.goZeroOverride
 		}
 		return overwrittenDefault(goType)
 	}

--- a/cmd/protoc-gen-go/internal_gengo/test_data/config.proto
+++ b/cmd/protoc-gen-go/internal_gengo/test_data/config.proto
@@ -10,5 +10,5 @@ extend google.protobuf.FieldOptions {
   optional string go_type = 1001;
   optional string go_import = 1002;
   optional string go_import_alias = 1003;
-  optional string zero_override = 1004;
+  optional string go_zero_override = 1004;
 }

--- a/cmd/protoc-gen-go/internal_gengo/test_data/config.proto
+++ b/cmd/protoc-gen-go/internal_gengo/test_data/config.proto
@@ -10,4 +10,5 @@ extend google.protobuf.FieldOptions {
   optional string go_type = 1001;
   optional string go_import = 1002;
   optional string go_import_alias = 1003;
+  optional string zero_override = 1004;
 }

--- a/cmd/protoc-gen-go/internal_gengo/test_data/test.proto
+++ b/cmd/protoc-gen-go/internal_gengo/test_data/test.proto
@@ -29,5 +29,5 @@ message Test {
   string optStr = 4 [(go_type) = "null.String", (go_import) = "github.com/volatiletech/null/v9", (go_import_alias) = "null"];
   int32 optInt = 5 [(go_type) = "null.Int32"];
   int32 optBigInt = 6 [(go_type) = "null.Int64", (go_import) = "github.com/volatiletech/null/v9", (go_import_alias) = "null"];
-  string something = 7 [(go_type) = "Something", (go_import) = "", (zero_override) = "\"\""];
+  string something = 7 [(go_type) = "Something", (go_import) = "", (go_zero_override) = "\"\""];
 }

--- a/cmd/protoc-gen-go/internal_gengo/test_data/test.proto
+++ b/cmd/protoc-gen-go/internal_gengo/test_data/test.proto
@@ -29,4 +29,5 @@ message Test {
   string optStr = 4 [(go_type) = "null.String", (go_import) = "github.com/volatiletech/null/v9", (go_import_alias) = "null"];
   int32 optInt = 5 [(go_type) = "null.Int32"];
   int32 optBigInt = 6 [(go_type) = "null.Int64", (go_import) = "github.com/volatiletech/null/v9", (go_import_alias) = "null"];
+  string something = 7 [(go_type) = "Something", (go_import) = "", (zero_override) = "\"\""];
 }

--- a/internal/impl/decode.go
+++ b/internal/impl/decode.go
@@ -23,10 +23,12 @@ const (
 	FieldOptionGoType        = "go_type"
 	FieldOptionGoImport      = "go_import"
 	FieldOptionGoImportAlias = "go_import_alias"
+	FieldOptionZeroOverride  = "zero_override"
 
 	FieldOptionGoTypeNum        = 1001
 	FieldOptionGoImportNum      = 1002
 	FieldOptionGoImportAliasNum = 1003
+	FieldOptionZeroOverrideNum  = 1004
 )
 
 var errDecode = errors.New("cannot parse invalid wire-format data")
@@ -281,6 +283,8 @@ func (mi *MessageInfo) fallbackCreateExtension(num protowire.Number) (protorefle
 		name = FieldOptionGoImport
 	case FieldOptionGoImportAliasNum:
 		name = FieldOptionGoImportAlias
+	case FieldOptionZeroOverrideNum:
+		name = FieldOptionZeroOverride
 	default:
 		return nil, errors.New("invalid name")
 	}

--- a/internal/impl/decode.go
+++ b/internal/impl/decode.go
@@ -20,15 +20,15 @@ import (
 )
 
 const (
-	FieldOptionGoType        = "go_type"
-	FieldOptionGoImport      = "go_import"
-	FieldOptionGoImportAlias = "go_import_alias"
-	FieldOptionZeroOverride  = "zero_override"
+	FieldOptionGoType         = "go_type"
+	FieldOptionGoImport       = "go_import"
+	FieldOptionGoImportAlias  = "go_import_alias"
+	FieldOptionGoZeroOverride = "go_zero_override"
 
-	FieldOptionGoTypeNum        = 1001
-	FieldOptionGoImportNum      = 1002
-	FieldOptionGoImportAliasNum = 1003
-	FieldOptionZeroOverrideNum  = 1004
+	FieldOptionGoTypeNum         = 1001
+	FieldOptionGoImportNum       = 1002
+	FieldOptionGoImportAliasNum  = 1003
+	FieldOptionGoZeroOverrideNum = 1004
 )
 
 var errDecode = errors.New("cannot parse invalid wire-format data")
@@ -283,8 +283,8 @@ func (mi *MessageInfo) fallbackCreateExtension(num protowire.Number) (protorefle
 		name = FieldOptionGoImport
 	case FieldOptionGoImportAliasNum:
 		name = FieldOptionGoImportAlias
-	case FieldOptionZeroOverrideNum:
-		name = FieldOptionZeroOverride
+	case FieldOptionGoZeroOverrideNum:
+		name = FieldOptionGoZeroOverride
 	default:
 		return nil, errors.New("invalid name")
 	}


### PR DESCRIPTION
#12 
I added `zero_override` to the field options. This manipulates the getters default return value directory. So based on the example from the ticket, if you are extending the message's field like this:
```
message Anything {
  string something = 1 [(go_type) = "Something", (go_import) = "", (zero_override)="\"\""];
}
``` 
You will get the following result in the related getter:
```
type Anything struct {
	Something Something

func (x *Anything) GetSomething() Something {
	if x != nil {
		return x.Something
	}
	return ""
}
```