### PR TITLE
Dockefile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN go build -o /out/protoc-gen-go-types .
 
 # Final
-FROM alpine:3.7
+FROM alpine:3.17
 
 COPY --from=go_builder /out/protoc-gen-go-types /usr/bin/protoc-gen-go-types
 RUN apk add --no-cache libstdc++ protobuf


### PR DESCRIPTION
In the *Dockerfile* for some unknown reason there was `alpine:3.7` instead of `alpine:3.17`, now the image contains the latest alpine version of ˙libprotoc` which is 3.21.9