### PR TITLE
Issue 16 Dockerfile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN go build -o /out/protoc-gen-go-types .
 FROM alpine:3.17
 
 COPY --from=go_builder /out/protoc-gen-go-types /usr/bin/protoc-gen-go-types
+RUN apk add protobuf-dev
 RUN apk add --no-cache libstdc++ protobuf
 
 CMD ["/usr/bin/protoc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN go build -o /out/protoc-gen-go-types .
 
 # Final
-FROM alpine:3.7
+FROM alpine:3.17
 
 COPY --from=go_builder /out/protoc-gen-go-types /usr/bin/protoc-gen-go-types
 RUN apk add --no-cache libstdc++ protobuf


### PR DESCRIPTION
In the *Dockerfile* for some reason there was `alpine:3.7` instead of `alpine:3.17`, now the image contains the latest alpine version of ˙libprotoc` which is 3.21.9