### PR TITLE
Handle the case if json tag was not overwritten

### DIFF
--- a/cmd/protoc-gen-go/internal_gengo/main.go
+++ b/cmd/protoc-gen-go/internal_gengo/main.go
@@ -602,9 +602,7 @@ func getAdditionalTags(m *messageInfo, field *protogen.Field) [][2]string {
 	if !contains(tags, func(kv [2]string) bool {
 		return kv[0] == "json"
 	}) {
-		return append([][2]string{
-			{"json", fieldJSONTagValue(field)},
-		}, tags...)
+		tags = append(tags, [2]string{"json", fieldJSONTagValue(field)})
 	}
 	return tags
 }

--- a/cmd/protoc-gen-go/internal_gengo/main.go
+++ b/cmd/protoc-gen-go/internal_gengo/main.go
@@ -616,7 +616,7 @@ func buildTags(wrappedTags string) [][2]string {
 			if len(submatch) != 3 {
 				continue
 			}
-			if submatch[1] == "protobuf_key" || submatch[1] == "protobuf_val" || submatch[1] == "protobuf" {
+			if submatch[1] == "protobuf_key" || submatch[1] == "protobuf_val" || submatch[1] == "protobuf" || submatch[1] == "protobuf_oneof" {
 				continue
 			}
 			tags = append(tags, [2]string{submatch[1], submatch[2]})

--- a/cmd/protoc-gen-go/internal_gengo/main.go
+++ b/cmd/protoc-gen-go/internal_gengo/main.go
@@ -598,7 +598,15 @@ func getAdditionalTags(m *messageInfo, field *protogen.Field) [][2]string {
 			{"json", fieldJSONTagValue(field)},
 		}
 	}
-	return buildTags(o.goStructTags)
+	tags := buildTags(o.goStructTags)
+	if !contains(tags, func(kv [2]string) bool {
+		return kv[0] == "json"
+	}) {
+		return append([][2]string{
+			{"json", fieldJSONTagValue(field)},
+		}, tags...)
+	}
+	return tags
 }
 
 func buildTags(wrappedTags string) [][2]string {
@@ -1121,4 +1129,13 @@ func (c trailingComment) String() string {
 		return ""
 	}
 	return s
+}
+
+func contains[E any](arr []E, f func(e E) bool) bool {
+	for _, e := range arr {
+		if found := f(e); found {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/protoc-gen-go/internal_gengo/main_test.go
+++ b/cmd/protoc-gen-go/internal_gengo/main_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/infiniteloopcloud/protoc-gen-go-types/compiler/protogen"
+	"github.com/infiniteloopcloud/protoc-gen-go-types/internal/filedesc"
 	"github.com/infiniteloopcloud/protoc-gen-go-types/parser"
 )
 
@@ -78,6 +79,55 @@ func TestGetAdditionalTags(t *testing.T) {
 	}
 	if tags[0][1] != "id_dont_know,omitempty" {
 		t.Errorf("First tag should be `id_dont_know,omitempty`, instead of %s", tags[0][1])
+	}
+	if tags[1][0] != "boil" {
+		t.Errorf("First tag should be `boil`, instead of %s", tags[1][0])
+	}
+	if tags[1][1] != "donno" {
+		t.Errorf("First tag should be `donno`, instead of %s", tags[1][1])
+	}
+	if tags[2][0] != "validate" {
+		t.Errorf("First tag should be `validate`, instead of %s", tags[2][0])
+	}
+	if tags[2][1] != "true" {
+		t.Errorf("First tag should be `true`, instead of %s", tags[2][1])
+	}
+}
+
+func TestGetAdditionalTagsNoJsonOverride(t *testing.T) {
+	TypeOverride = true
+	overrideFields = map[string]map[string]overrideParams{
+		"TestStruct": {
+			"TestField": overrideParams{
+				goStructTags: `omitempty;boil=donno;validate=true`,
+			},
+		},
+	}
+	tags := getAdditionalTags(&messageInfo{
+		Message: &protogen.Message{
+			GoIdent: protogen.GoIdent{
+				GoName: "TestStruct",
+			},
+		},
+	}, &protogen.Field{
+		GoName: "TestField",
+		Desc: &filedesc.Field{
+			Base: filedesc.Base{
+				L0: filedesc.BaseL0{
+					FullName: "my_test_field",
+				},
+			},
+		},
+	})
+
+	if len(tags) != 3 {
+		t.Fatal("Tags length must be 3")
+	}
+	if tags[0][0] != "json" {
+		t.Errorf("First tag should be `json`, instead of %s", tags[0][0])
+	}
+	if tags[0][1] != "my_test_field,omitempty" {
+		t.Errorf("First tag should be `my_test_field,omitempty`, instead of %s", tags[0][1])
 	}
 	if tags[1][0] != "boil" {
 		t.Errorf("First tag should be `boil`, instead of %s", tags[1][0])


### PR DESCRIPTION
If the `json` tag was not present in the go_struct_tags option, the lib would use the default `json` tag, generated by protobuf.
#22 